### PR TITLE
[incomplete]Waterfox addons

### DIFF
--- a/waterfox-kde/usr.bin.waterfox
+++ b/waterfox-kde/usr.bin.waterfox
@@ -82,7 +82,9 @@
   # waterfox specific
   /etc/waterfox*/ r,
   /etc/waterfox*/** r,
-  
+  /usr/lib/waterfox-addons*/ r,
+  /usr/lib/waterfox-addons*/** r
+
   # firefox specific
   #/etc/xul-ext/** r,
   #/etc/xulrunner-2.0*/ r,

--- a/waterfox-kde/waterfox-kde.links
+++ b/waterfox-kde/waterfox-kde.links
@@ -14,3 +14,6 @@ usr/share/hyphen usr/lib/waterfox/hyphenation
 
 # Wrapper
 usr/lib/waterfox/waterfox-bin.sh usr/bin/waterfox
+
+#etc
+etc/waterfox/syspref.js usr/lib/waterfox/browser/defaults/preferences

--- a/waterfox-kde/waterfox-kde.links
+++ b/waterfox-kde/waterfox-kde.links
@@ -17,3 +17,8 @@ usr/lib/waterfox/waterfox-bin.sh usr/bin/waterfox
 
 #etc
 etc/waterfox/syspref.js usr/lib/waterfox/browser/defaults/preferences
+
+#waterfox-addons
+usr/lib/waterfox-addons/searchplugins usr/lib/waterfox/browser/searchplugins
+usr/lib/waterfox-addons/plugins usr/lib/waterfox/browser/plugins
+usr/lib/waterfox-addons/extensions usr/lib/waterfox/browser/extensions

--- a/waterfox/usr.bin.waterfox
+++ b/waterfox/usr.bin.waterfox
@@ -82,7 +82,9 @@
   # waterfox specific
   /etc/waterfox*/ r,
   /etc/waterfox*/** r,
-  
+  /usr/lib/waterfox-addons*/ r,
+  /usr/lib/waterfox-addons*/** r
+
   # firefox specific
   #/etc/xul-ext/** r,
   #/etc/xulrunner-2.0*/ r,

--- a/waterfox/waterfox.links
+++ b/waterfox/waterfox.links
@@ -14,3 +14,6 @@ usr/share/hyphen usr/lib/waterfox/hyphenation
 
 # Wrapper
 usr/lib/waterfox/waterfox-bin.sh usr/bin/waterfox
+
+#etc
+etc/waterfox/syspref.js usr/lib/waterfox/browser/defaults/preferences

--- a/waterfox/waterfox.links
+++ b/waterfox/waterfox.links
@@ -17,3 +17,8 @@ usr/lib/waterfox/waterfox-bin.sh usr/bin/waterfox
 
 #etc
 etc/waterfox/syspref.js usr/lib/waterfox/browser/defaults/preferences
+
+#waterfox-addons
+usr/lib/waterfox-addons/searchplugins usr/lib/waterfox/browser/searchplugins
+usr/lib/waterfox-addons/plugins usr/lib/waterfox/browser/plugins
+usr/lib/waterfox-addons/extensions usr/lib/waterfox/browser/extensions


### PR DESCRIPTION
I think i create empty folders linked from /usr/lib/waterfox-addons to /usr/lib/waterfox

It's like firefox. problem, there's an extension in
/usr/lib/waterfox/browser/extensions ? I can't open it, shouldn't be in /usr/lib/waterfox/browser/features ???